### PR TITLE
make btnap.service start before networking.service

### DIFF
--- a/files/etc/systemd/system/btnap.service
+++ b/files/etc/systemd/system/btnap.service
@@ -17,8 +17,15 @@
 After=bluetooth.service
 PartOf=bluetooth.service
 
+Before=network-pre.target
+Wants=network-pre.target
+After=local-fs.target
+Requires=local-fs.target
+
 [Service]
+Type=oneshot
 ExecStart=/usr/local/sbin/btnap.service.sh
+RemainAfterExit=yes
 
 [Install]
-WantedBy=bluetooth.target
+WantedBy=bluetooth.target network.target


### PR DESCRIPTION
As described here: https://superuser.com/questions/1005742/how-to-run-script-before-the-network-configuration.

I also have to check this against the creation of an AP as opposed to just connecting to an existing network. 

And DHCP has to be enabled in `/etc/network/interfaces` this way:
```
auto bnepX
iface bnepX inet dhcp
```
Where X is the index of the interface.